### PR TITLE
Compile with mingw on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Code
+*.c text
+*.clj text
+
+# Documentation
+*.adoc text
+LICENSE text
+
+# Config formats
+*.edn
+*.json text
+*.kak text
+*.lock text
+*.nix text
+*.yaml text
+*.yml text
+.envrc text
+Makefile text
+.gitignore text
+
+# Objects
+*.lib binary
+*.exe binary
+*.dll binary
+*.o binary
+*.a binary
+*.so binary
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pom.xml.asc
 /result
 /.cpcache
 /rep
+/rep.exe
 /rep.1
 *.dSYM
 /.direnv

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-
 prefix	= /usr/local
+ifeq ($(OS),Windows_NT)
+	CC=gcc
+	LIBS=-lws2_32
+	prefix="C:\\Program Files\\rep"
+endif
 
 all: rep test rep.1
 
 rep: rep.c
-	$(CC) -g -O2 -o rep rep.c
+	$(CC) -g -O2 -o rep rep.c $(LIBS)
+
 
 rep.1: rep.1.adoc
 	a2x -f manpage rep.1.adoc


### PR DESCRIPTION
This PR allows `rep` to be compiled with mingw on Windows. I have printed help page, and successfully connected to a repl with the compiled result. 

To compile, simply run:

```
mingw32-make.exe
```

from the root directory of the repository.