### PR TITLE
Correctly detect macOS devices when importing headers

### DIFF
--- a/rep.c
+++ b/rep.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
 #include <alloca.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Building `rep` on an M1 running macOS Ventura (13.1) fails: `use of undeclared identifier 'IPPROTO_TCP'` and friends.

A similar issue has been encountered in https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/300. It appears that `<netinet/in.h>` is not imported correctly on Apple systems.

<details>

<summary>Full build output</summary>

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/b9yc1an3xqlaq95lv68xhbya3wgzmazz-3dwlyr0v1asj925128izynm0iq7sqbnb-source
source root is 3dwlyr0v1asj925128izynm0iq7sqbnb-source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
build flags: SHELL=/nix/store/1xprix2z0194xyqgz0xk7id16pxn6yy6-bash-5.1-p16/bin/bash prefix=\$\(out\)
clang -g -O2 -o rep rep.c
rep.c:406:17: warning: implicit declaration of function 'recv' is invalid in C99 [-Wimplicit-function-declaration]
    int count = recv(reader->fd, &ch, 1, 0);
                ^
rep.c:626:20: error: incomplete result type 'struct sockaddr_in' in function definition
struct sockaddr_in options_address_from_file(struct options* options, const char* filename)
                   ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:631:12: error: calling 'options_address' with incomplete return type 'struct sockaddr_in'
    return options_address(options, linebuffer);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rep.c:610:20: note: 'options_address' declared here
struct sockaddr_in options_address(struct options* options, const char* port);
                   ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:634:20: error: incomplete result type 'struct sockaddr_in' in function definition
struct sockaddr_in options_address_from_relative_file(struct options* options, const char* directory_in, const char* filename)
                   ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:652:32: error: variable has incomplete type 'struct sockaddr_in'
            struct sockaddr_in result = options_address_from_file(options, path_to_check);
                               ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:686:20: error: incomplete result type 'struct sockaddr_in' in function definition
struct sockaddr_in options_address(struct options* options, const char* port)
                   ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:695:28: error: variable has incomplete type 'struct sockaddr_in'
        struct sockaddr_in result = options_address_from_relative_file(options, absolute_directory, filename);
                           ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:702:23: error: use of undeclared identifier 'AF_INET'
        .sin_family = AF_INET,
                      ^
rep.c:703:34: error: use of undeclared identifier 'INADDR_LOOPBACK'
        .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
                                 ^
rep.c:703:34: error: use of undeclared identifier 'INADDR_LOOPBACK'
rep.c:703:34: error: use of undeclared identifier 'INADDR_LOOPBACK'
rep.c:703:34: error: use of undeclared identifier 'INADDR_LOOPBACK'
rep.c:703:34: error: use of undeclared identifier 'INADDR_LOOPBACK'
rep.c:703:34: error: use of undeclared identifier 'INADDR_LOOPBACK'
rep.c:700:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in address =
                       ^
rep.c:610:8: note: forward declaration of 'struct sockaddr_in'
struct sockaddr_in options_address(struct options* options, const char* port);
       ^
rep.c:719:35: warning: implicit declaration of function 'gethostbyname' is invalid in C99 [-Wimplicit-function-declaration]
            struct hostent *ent = gethostbyname(host_part);
                                  ^
rep.c:719:29: warning: incompatible integer to pointer conversion initializing 'struct hostent *' with an expression of type 'int' [-Wint-conversion]
            struct hostent *ent = gethostbyname(host_part);
                            ^     ~~~~~~~~~~~~~~~~~~~~~~~~
rep.c:722:28: error: incomplete definition of type 'struct hostent'
            if (NULL == ent->h_addr)
                        ~~~^
rep.c:719:20: note: forward declaration of 'struct hostent'
            struct hostent *ent = gethostbyname(host_part);
                   ^
rep.c:727:53: error: incomplete definition of type 'struct hostent'
            address.sin_addr.s_addr = *(u_long *)ent->h_addr_list[0];
                                                 ~~~^
rep.c:719:20: note: forward declaration of 'struct hostent'
            struct hostent *ent = gethostbyname(host_part);
                   ^
rep.c:947:17: warning: implicit declaration of function 'socket' is invalid in C99 [-Wimplicit-function-declaration]
    nrepl->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                ^
rep.c:947:24: error: use of undeclared identifier 'AF_INET'
    nrepl->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                       ^
rep.c:947:33: error: use of undeclared identifier 'SOCK_STREAM'
    nrepl->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                                ^
rep.c:947:46: error: use of undeclared identifier 'IPPROTO_TCP'
    nrepl->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                                             ^
rep.c:1037:9: warning: implicit declaration of function 'send' is invalid in C99 [-Wimplicit-function-declaration]
    if (send(nrepl->fd, message, length, 0) != length)
        ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
5 warnings and 20 errors generated.
make: *** [Makefile:11: rep] Error 1
```

</details>